### PR TITLE
feat(header): brand colors (yellow/charcoal), nav a11y, contact drawer

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -59,5 +59,22 @@
 </main>
 <footer id="site-footer"></footer>
 <div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<aside id="contactDrawer" hidden>
+  <div class="overlay"></div>
+  <div class="drawer-panel">
+    <div class="drawer-header">
+      <h2>Contacto</h2>
+      <button class="drawer-close" aria-label="Cerrar">×</button>
+    </div>
+    <div class="drawer-content">
+      <form id="contactForm">
+        <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
+        <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
+        <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
+        <button type="submit" class="btn">Enviar</button>
+      </form>
+    </div>
+  </div>
+</aside>
 </body>
 </html>

--- a/css/base.css
+++ b/css/base.css
@@ -1,8 +1,13 @@
 :root {
-  --color-primary: #e60012;
-  --color-dark: #222;
-  --color-light: #fff;
-  --color-gray: #f5f5f5;
+  --bg: #ffffff;
+  --text: #0b0f19;
+  --muted: #6b7280;
+  --line: #e5e7eb;
+  --header-bg: #0F1117;
+  --header-text: #E5EAF0;
+  --brand: #F59E0B;
+  --brand-hover: #D97706;
+  --focus: #FDE68A;
   --font-base: Arial, sans-serif;
 }
 
@@ -15,8 +20,8 @@
 body {
   font-family: var(--font-base);
   line-height: 1.5;
-  color: var(--color-dark);
-  background: var(--color-light);
+  color: var(--text);
+  background: var(--bg);
 }
 
 img {
@@ -46,14 +51,21 @@ button {
 .btn {
   display: inline-block;
   padding: 0.75rem 1.5rem;
-  background: var(--color-primary);
-  color: var(--color-light);
+  background: var(--brand);
+  color: var(--header-bg);
   border: none;
   text-align: center;
+  transition: background 0.2s;
+}
+
+.btn:hover,
+.btn:focus {
+  background: var(--brand-hover);
 }
 
 .btn.secondary {
-  background: var(--color-dark);
+  background: var(--text);
+  color: var(--bg);
 }
 
 input,
@@ -61,11 +73,11 @@ select,
 textarea {
   width: 100%;
   padding: 0.5rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--line);
 }
 
 :focus {
-  outline: 2px solid var(--color-primary);
+  outline: 2px solid var(--focus);
   outline-offset: 2px;
 }
 
@@ -78,4 +90,4 @@ p {margin-bottom:1rem;}
 section {padding:3rem 0;}
 
 .table {width:100%;border-collapse:collapse;}
-.table th,.table td{border:1px solid #ddd;padding:0.5rem;text-align:left;}
+.table th,.table td{border:1px solid var(--line);padding:0.5rem;text-align:left;}

--- a/css/components.css
+++ b/css/components.css
@@ -2,8 +2,9 @@
 .header {
   position: sticky;
   top: 0;
-  background: var(--color-light);
-  border-bottom: 1px solid #eee;
+  background: var(--header-bg);
+  color: var(--header-text);
+  border-bottom: 1px solid var(--line);
   z-index: 1000;
 }
 .topbar {
@@ -15,21 +16,32 @@
 .logo img {height:40px;}
 .nav ul {list-style:none;display:flex;gap:1rem;}
 .nav .has-sub {position:relative;}
-.nav .has-sub button {background:none;}
-.nav .submenu {display:none;position:absolute;top:100%;left:0;background:var(--color-light);border:1px solid #ddd;padding:0.5rem;min-width:200px;}
-.nav .submenu a {display:block;padding:0.25rem 0;}
-.nav .has-sub.open .submenu {display:block;}
-.icons {display:flex;gap:0.5rem;align-items:center;}
-.badge {background:var(--color-primary);color:#fff;border-radius:50%;padding:0 6px;font-size:0.75rem;margin-left:2px;}
+.nav a,
+.nav button {color:var(--header-text);background:none;padding:0.25rem 0;}
+.nav a:hover,
+.nav button:hover,
+.nav a:focus,
+.nav button:focus {color:var(--brand);}
+.nav .submenu {position:absolute;top:100%;left:0;background:var(--header-bg);border:1px solid var(--line);padding:0.5rem;min-width:200px;opacity:0;transform:translateY(0.5rem);transition:opacity 0.25s ease,transform 0.25s ease;}
+.nav .submenu[hidden]{display:none;}
+.nav .submenu.open {opacity:1;transform:translateY(0);}
+.nav .submenu a {display:block;padding:0.25rem 0;color:var(--header-text);}
+.nav .submenu a:hover,
+.nav .submenu a:focus {background:var(--brand);color:var(--header-bg);}
+.actions {display:flex;gap:0.5rem;align-items:center;}
+.actions button{color:var(--header-text);}
+.actions button:hover,
+.actions button:focus{color:var(--brand);}
+.badge {background:var(--brand);color:var(--header-bg);border-radius:50%;padding:0 6px;font-size:0.75rem;margin-left:2px;}
 
 /* Drawer */
-.drawer {position:fixed;top:0;right:-100%;width:300px;height:100%;background:#fff;box-shadow:-2px 0 6px rgba(0,0,0,0.2);transition:right 0.3s;z-index:2000;display:flex;flex-direction:column;}
+.drawer {position:fixed;top:0;right:-100%;width:300px;height:100%;background:var(--bg);color:var(--text);box-shadow:-2px 0 6px rgba(0,0,0,0.2);transition:right 0.3s;z-index:2000;display:flex;flex-direction:column;}
 .drawer.open {right:0;}
-.drawer-header {display:flex;justify-content:space-between;align-items:center;padding:1rem;border-bottom:1px solid #eee;}
+.drawer-header {display:flex;justify-content:space-between;align-items:center;padding:1rem;border-bottom:1px solid var(--line);}
 .drawer-content {flex:1;overflow:auto;padding:1rem;}
-.drawer-footer {padding:1rem;border-top:1px solid #eee;}
+.drawer-footer {padding:1rem;border-top:1px solid var(--line);}
 .cart-item {display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem;}
-.cart-item button{padding:0.25rem 0.5rem;background:var(--color-gray);}
+.cart-item button{padding:0.25rem 0.5rem;background:var(--line);}
 
 /* Hero */
 .hero {background:#f0f0f0;padding:4rem 0;text-align:center;}
@@ -48,29 +60,30 @@
 
 /* Reviews */
 .reviews-list{list-style:none;display:grid;gap:1rem;}
-.review{border:1px solid #ddd;padding:1rem;}
-.review .rating{color:#f5a623;}
+.review{border:1px solid var(--line);padding:1rem;}
+.review .rating{color:var(--brand);}
 
 /* Buy box */
 .product {display:grid;gap:2rem;}
 .gallery{display:flex;gap:1rem;}
 .gallery-thumbs{display:flex;flex-direction:column;gap:0.5rem;}
-.gallery-thumbs img{width:60px;height:60px;object-fit:cover;cursor:pointer;border:1px solid #ddd;}
-.buy-box{border:1px solid #ddd;padding:1rem;}
+.gallery-thumbs img{width:60px;height:60px;object-fit:cover;cursor:pointer;border:1px solid var(--line);}
+.buy-box{border:1px solid var(--line);padding:1rem;}
 .badges{display:flex;gap:0.5rem;margin:0.5rem 0;}
-.badge-pill{background:var(--color-gray);padding:0.25rem 0.5rem;font-size:0.875rem;}
-.sticky-bar{position:fixed;bottom:-100px;left:0;right:0;background:#fff;border-top:1px solid #ddd;padding:0.5rem;display:flex;justify-content:space-between;align-items:center;transition:bottom 0.3s;z-index:1500;}
+.badge-pill{background:var(--brand);color:var(--header-bg);padding:0.25rem 0.5rem;font-size:0.875rem;}
+.sticky-bar{position:fixed;bottom:-100px;left:0;right:0;background:var(--bg);border-top:1px solid var(--line);padding:0.5rem;display:flex;justify-content:space-between;align-items:center;transition:bottom 0.3s;z-index:1500;}
 .sticky-bar.show{bottom:0;}
 
 /* Accordion */
-.accordion-item{border-bottom:1px solid #ddd;}
-.accordion-button{width:100%;text-align:left;padding:1rem;background:var(--color-light);}
+.accordion-item{border-bottom:1px solid var(--line);}
+.accordion-button{width:100%;text-align:left;padding:1rem;background:var(--bg);}
 .accordion-content{display:none;padding:0 1rem 1rem;}
 .accordion-item.open .accordion-content{display:block;}
 
 /* Footer */
-.footer{background:#222;color:#fff;padding:2rem 0;}
-.footer a{color:#fff;}
+.footer{background:var(--header-bg);color:var(--header-text);padding:2rem 0;}
+.footer a{color:var(--header-text);}
+.footer a:hover{color:var(--brand-hover);}
 .footer-columns{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;}
 
 /* Checkout */
@@ -82,3 +95,11 @@
 
 /* Service */
 .service-section{margin-bottom:2rem;}
+
+/* Contact drawer */
+#contactDrawer[hidden]{display:none;}
+#contactDrawer{position:fixed;inset:0;display:flex;justify-content:flex-end;background:rgba(0,0,0,0.5);opacity:0;pointer-events:none;transition:opacity 0.3s;z-index:2100;}
+#contactDrawer.open{opacity:1;pointer-events:auto;}
+#contactDrawer .drawer-panel{background:var(--bg);color:var(--text);width:300px;max-width:90%;height:100%;box-shadow:-2px 0 6px rgba(0,0,0,0.2);display:flex;flex-direction:column;transform:translateX(100%);transition:transform 0.3s;}
+#contactDrawer.open .drawer-panel{transform:translateX(0);}
+#contactDrawer .overlay{flex:1;}

--- a/g2-pro.html
+++ b/g2-pro.html
@@ -79,6 +79,23 @@
 </main>
 <footer id="site-footer"></footer>
 <div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<aside id="contactDrawer" hidden>
+  <div class="overlay"></div>
+  <div class="drawer-panel">
+    <div class="drawer-header">
+      <h2>Contacto</h2>
+      <button class="drawer-close" aria-label="Cerrar">×</button>
+    </div>
+    <div class="drawer-content">
+      <form id="contactForm">
+        <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
+        <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
+        <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
+        <button type="submit" class="btn">Enviar</button>
+      </form>
+    </div>
+  </div>
+</aside>
 <div id="buy-bar" class="sticky-bar"><span>$1100</span><button class="btn" onclick="addProduct(PRODUCT.sku,PRODUCT.nombre,PRODUCT.precioUSD)">Añadir</button></div>
 <script type="application/ld+json">
 {

--- a/index.html
+++ b/index.html
@@ -58,5 +58,22 @@
 </main>
 <footer id="site-footer"></footer>
 <div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<aside id="contactDrawer" hidden>
+  <div class="overlay"></div>
+  <div class="drawer-panel">
+    <div class="drawer-header">
+      <h2>Contacto</h2>
+      <button class="drawer-close" aria-label="Cerrar">×</button>
+    </div>
+    <div class="drawer-content">
+      <form id="contactForm">
+        <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
+        <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
+        <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
+        <button type="submit" class="btn">Enviar</button>
+      </form>
+    </div>
+  </div>
+</aside>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -69,17 +69,18 @@ function renderHeader(){
       <a class="logo" href="index.html"><img src="assets/logo.png" alt="Quality360"></a>
       <nav class="nav" aria-label="Principal">
         <ul>
-          <li class="has-sub"><button aria-haspopup="true">Monopatines ▾</button>
-            <div class="submenu" role="menu">
+          <li><a href="index.html">Home</a></li>
+          <li class="has-sub"><button aria-haspopup="true" aria-expanded="false">Monopatines ▾</button>
+            <div class="submenu" role="menu" hidden>
               <a href="g2-pro.html" role="menuitem">KuKirin G2 Pro</a>
             </div>
           </li>
-          <li class="has-sub"><button aria-haspopup="true">Servicio ▾</button>
-            <div class="submenu" role="menu">
+          <li class="has-sub"><button aria-haspopup="true" aria-expanded="false">Servicio ▾</button>
+            <div class="submenu" role="menu" hidden>
               <a href="service.html#ayuda" role="menuitem">Centro de ayuda</a>
               <a href="service.html#faq" role="menuitem">Preguntas frecuentes</a>
               <a href="service.html#montaje" role="menuitem">Fácil montaje</a>
-              <a href="service.html#manual" role="menuitem">Manual del monopatín</a>
+              <a href="service.html#manual" role="menuitem">Manual del patinete</a>
               <a href="service.html#garantia" role="menuitem">Garantía</a>
               <a href="service.html#envios" role="menuitem">Política de envíos</a>
               <a href="service.html#reembolso" role="menuitem">Política de reembolso</a>
@@ -87,11 +88,11 @@ function renderHeader(){
               <a href="service.html#distribuidor" role="menuitem">Conviértete en distribuidor</a>
             </div>
           </li>
+          <li><a href="index.html#reviews">Reseñas</a></li>
         </ul>
       </nav>
-      <div class="icons">
-        <button aria-label="Buscar">🔍</button>
-        <button aria-label="Cuenta">👤</button>
+      <div class="actions">
+        <button id="contact-btn" aria-controls="contactDrawer" aria-expanded="false">Contacto</button>
         <button id="cart-btn" aria-label="Carrito">🛒<span id="cart-count" class="badge">0</span></button>
       </div>
     </div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,25 +1,113 @@
-// Toggle submenus
+let closeNavMenus = () => {};
+
 function initNav(){
-  $$('.nav .has-sub > button').forEach(btn=>{
-    btn.addEventListener('click',()=>{
-      const li = btn.parentElement;
-      li.classList.toggle('open');
+  const nav = document.querySelector('.nav');
+  if(!nav) return;
+  const buttons = $$('.has-sub > button', nav);
+
+  function hide(menu){
+    menu.classList.remove('open');
+    menu.addEventListener('transitionend', ()=>{menu.hidden = true;}, {once:true});
+  }
+  function closeAll(){
+    buttons.forEach(btn => {
+      const submenu = btn.nextElementSibling;
+      if(!submenu.hidden){
+        btn.setAttribute('aria-expanded','false');
+        hide(submenu);
+      }
+    });
+  }
+  closeNavMenus = closeAll;
+
+  buttons.forEach(btn => {
+    const submenu = btn.nextElementSibling;
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      if(btn.getAttribute('aria-expanded') === 'true'){
+        closeAll();
+      }else{
+        closeAll();
+        submenu.hidden = false;
+        requestAnimationFrame(()=> submenu.classList.add('open'));
+        btn.setAttribute('aria-expanded','true');
+      }
+    });
+    btn.parentElement.addEventListener('mouseenter', () => {
+      if(window.matchMedia('(min-width:768px)').matches){
+        if(btn.getAttribute('aria-expanded') !== 'true'){
+          closeAll();
+          submenu.hidden = false;
+          requestAnimationFrame(()=> submenu.classList.add('open'));
+          btn.setAttribute('aria-expanded','true');
+        }
+      }
     });
   });
+
+  nav.addEventListener('mouseleave', () => {
+    if(window.matchMedia('(min-width:768px)').matches) closeAll();
+  });
+
+  document.addEventListener('click', e => {
+    if(!nav.contains(e.target)) closeAll();
+  });
+  document.addEventListener('keydown', e => { if(e.key === 'Escape') closeAll(); });
+  window.addEventListener('scroll', closeAll);
+  $$('.nav a').forEach(a => a.addEventListener('click', closeAll));
 }
 
-// Cart drawer
-function initDrawer(){
+function initCartDrawer(){
   const btn = document.getElementById('cart-btn');
   const drawer = document.getElementById('cart-drawer');
   if(!btn || !drawer) return;
-  btn.addEventListener('click',()=> drawer.classList.add('open'));
-  drawer.addEventListener('click',e=>{
-    if(e.target.classList.contains('drawer-close')||e.target===drawer) drawer.classList.remove('open');
+  btn.addEventListener('click', () => {
+    closeNavMenus();
+    drawer.classList.add('open');
+  });
+  drawer.addEventListener('click', e => {
+    if(e.target.classList.contains('drawer-close') || e.target === drawer) drawer.classList.remove('open');
+  });
+  document.addEventListener('keydown', e => { if(e.key === 'Escape') drawer.classList.remove('open'); });
+}
+
+function initContactDrawer(){
+  const btn = document.getElementById('contact-btn');
+  const drawer = document.getElementById('contactDrawer');
+  if(!btn || !drawer) return;
+  const overlay = drawer.querySelector('.overlay');
+  const closeBtn = drawer.querySelector('.drawer-close');
+  const form = drawer.querySelector('form');
+
+  function open(){
+    closeNavMenus();
+    btn.setAttribute('aria-expanded','true');
+    drawer.hidden = false;
+    requestAnimationFrame(()=> drawer.classList.add('open'));
+  }
+  function close(){
+    btn.setAttribute('aria-expanded','false');
+    drawer.classList.remove('open');
+    drawer.addEventListener('transitionend', ()=>{drawer.hidden = true;}, {once:true});
+  }
+
+  btn.addEventListener('click', e => { e.preventDefault(); open(); });
+  overlay.addEventListener('click', close);
+  closeBtn.addEventListener('click', close);
+  document.addEventListener('keydown', e => { if(e.key === 'Escape') close(); });
+  window.addEventListener('scroll', close);
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const name = encodeURIComponent($('#contactName').value);
+    const email = encodeURIComponent($('#contactEmail').value);
+    const msg = encodeURIComponent($('#contactMessage').value);
+    const body = `Nombre: ${name}%0AEmail: ${email}%0AMensaje: ${msg}`;
+    window.location.href = `mailto:quality360store@gmail.com?subject=Consulta%20Quality360&body=${body}`;
+    close();
   });
 }
 
-// Accordion
 function initAccordion(){
   $$('.accordion-button').forEach(btn=>{
     btn.addEventListener('click',()=>{
@@ -29,7 +117,6 @@ function initAccordion(){
   });
 }
 
-// Sticky buy bar
 function initStickyBar(){
   const bar = document.getElementById('buy-bar');
   if(!bar) return;
@@ -40,7 +127,9 @@ function initStickyBar(){
 
 window.addEventListener('DOMContentLoaded',()=>{
   initNav();
-  initDrawer();
+  initCartDrawer();
+  initContactDrawer();
   initAccordion();
   initStickyBar();
 });
+

--- a/service.html
+++ b/service.html
@@ -31,5 +31,22 @@
 </main>
 <footer id="site-footer"></footer>
 <div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<aside id="contactDrawer" hidden>
+  <div class="overlay"></div>
+  <div class="drawer-panel">
+    <div class="drawer-header">
+      <h2>Contacto</h2>
+      <button class="drawer-close" aria-label="Cerrar">×</button>
+    </div>
+    <div class="drawer-content">
+      <form id="contactForm">
+        <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
+        <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
+        <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
+        <button type="submit" class="btn">Enviar</button>
+      </form>
+    </div>
+  </div>
+</aside>
 </body>
 </html>

--- a/success.html
+++ b/success.html
@@ -24,5 +24,22 @@
 </main>
 <footer id="site-footer"></footer>
 <div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<aside id="contactDrawer" hidden>
+  <div class="overlay"></div>
+  <div class="drawer-panel">
+    <div class="drawer-header">
+      <h2>Contacto</h2>
+      <button class="drawer-close" aria-label="Cerrar">×</button>
+    </div>
+    <div class="drawer-content">
+      <form id="contactForm">
+        <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
+        <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
+        <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
+        <button type="submit" class="btn">Enviar</button>
+      </form>
+    </div>
+  </div>
+</aside>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- apply yellow/charcoal design tokens
- rebuild navigation with accessible hover/click submenus and contact button
- add right-side contact drawer with simple mailto form

## Testing
- `node --check js/app.js`
- `node --check js/ui.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce2c29308832e8d63d512da143c6b