### PR TITLE
Refactor móvil: header/drawer, botones, home, reseñas y footer (+CTA PDP)

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -41,7 +41,7 @@
       <p id="pickup-info"></p>
       <textarea placeholder="Notas de entrega"></textarea>
     </section>
-    <button class="btn" type="submit">Finalizar compra</button>
+    <button class="btn btn--primary" type="submit">Finalizar compra</button>
   </form>
   <aside class="checkout-summary">
     <h2>Resumen</h2>
@@ -71,7 +71,7 @@
         <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
         <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
         <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
-        <button type="submit" class="btn">Enviar</button>
+        <button type="submit" class="btn btn--primary">Enviar</button>
       </form>
     </div>
   </div>

--- a/css/base.css
+++ b/css/base.css
@@ -5,8 +5,8 @@
   --line: #e5e7eb;
   --header-bg: #0F1117;
   --header-text: #E5EAF0;
-  --brand: #F59E0B;
-  --brand-hover: #D97706;
+  --brand: #FFC107;
+  --brand-hover: #E0A800;
   --focus: #FDE68A;
   --font-base: Arial, sans-serif;
 }
@@ -51,21 +51,32 @@ button {
 .btn {
   display: inline-block;
   padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  transition: transform 0.15s, box-shadow 0.15s;
+  text-align: center;
+}
+
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn--primary {
   background: var(--brand);
   color: var(--header-bg);
-  border: none;
-  text-align: center;
-  transition: background 0.2s;
+}
+.btn--primary:hover,
+.btn--primary:focus {
+  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
 }
 
-.btn:hover,
-.btn:focus {
-  background: var(--brand-hover);
+.btn--dark {
+  background: var(--header-bg);
+  color: var(--header-text);
 }
-
-.btn.secondary {
-  background: var(--text);
-  color: var(--bg);
+.btn--dark:hover,
+.btn--dark:focus {
+  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
 }
 
 input,

--- a/css/components.css
+++ b/css/components.css
@@ -2,9 +2,9 @@
 .header {
   position: sticky;
   top: 0;
-  background: var(--bg);
-  color: var(--text);
-  border-bottom: 1px solid var(--line);
+  background: var(--header-bg);
+  color: var(--header-text);
+  border-bottom: 1px solid rgba(255,255,255,0.05);
   z-index: 1000;
 }
 .topbar {
@@ -14,8 +14,8 @@
   padding: 0.5rem 0;
 }
 .logo img {height:40px;}
-.nav {justify-self: center;}
-.nav ul {list-style:none;display:flex;}
+.nav {justify-self:center;display:none;}
+.nav ul {list-style:none;display:flex;gap:1rem;}
 .nav .has-sub {position:relative;}
 .nav a,
 .nav button {color:inherit;background:none;}
@@ -27,10 +27,10 @@
   position:absolute;
   top:100%;
   left:0;
-  background: var(--bg);
-  border:1px solid var(--line);
+  background: var(--header-bg);
+  border:1px solid rgba(255,255,255,0.1);
   border-radius:12px;
-  box-shadow:0 4px 12px rgba(0,0,0,0.1);
+  box-shadow:0 4px 12px rgba(0,0,0,0.3);
   padding:8px 0;
   min-width:220px;
   opacity:0;
@@ -43,12 +43,12 @@
 .nav .submenu a {
   display:block;
   padding:10px 14px;
-  color:var(--text);
+  color:var(--header-text);
   transition:background 0.15s ease;
 }
 .nav .submenu a:hover,
 .nav .submenu a:focus {
-  background:rgba(0,0,0,0.05);
+  background:rgba(255,255,255,0.05);
 }
 .actions {
   display:flex;
@@ -84,6 +84,10 @@
   display:none;
 }
 .nav-overlay.show{display:block;}
+@media(min-width:768px){
+  .nav{display:block;}
+  #menu-btn{display:none;}
+}
 
 /* Drawer */
 .drawer {position:fixed;top:0;right:-100%;width:300px;height:100%;background:var(--bg);color:var(--text);box-shadow:-2px 0 6px rgba(0,0,0,0.2);transition:right 0.3s;z-index:2000;display:flex;flex-direction:column;}
@@ -94,25 +98,59 @@
 .cart-item {display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem;}
 .cart-item button{padding:0.25rem 0.5rem;background:var(--line);}
 
+/* Nav drawer */
+#navDrawer[hidden]{display:none;}
+#navDrawer{position:fixed;inset:0;display:flex;justify-content:flex-start;background:rgba(0,0,0,0.5);opacity:0;pointer-events:none;transition:opacity 0.3s;z-index:2100;}
+#navDrawer.open{opacity:1;pointer-events:auto;}
+#navDrawer .drawer-panel{background:var(--bg);color:var(--text);width:260px;max-width:90%;height:100%;box-shadow:2px 0 6px rgba(0,0,0,0.2);display:flex;flex-direction:column;transform:translateX(-100%);transition:transform 0.3s;}
+#navDrawer.open .drawer-panel{transform:translateX(0);}
+#navDrawer .overlay{flex:1;}
+#navDrawer nav ul{list-style:none;padding:1rem;}
+#navDrawer nav li{margin-bottom:0.5rem;}
+#navDrawer nav a{display:block;padding:0.75rem 0;color:var(--text);}
+#navDrawer nav a:hover,#navDrawer nav a:focus{color:var(--brand);}
+
 /* Hero */
-.hero {background:#f0f0f0;padding:4rem 0;text-align:center;}
-.hero h1 {font-size:2rem;margin-bottom:1rem;}
-.hero .btn-group {margin-top:1rem;display:flex;gap:1rem;justify-content:center;}
+.hero{position:relative;overflow:hidden;height:clamp(420px,58vh,560px);}
+@media(min-width:768px){.hero{height:clamp(520px,68vh,680px);}}
+.hero__slides{height:100%;position:relative;}
+.hero__slide{position:absolute;inset:0;background-size:cover;background-position:center var(--hero-focus-y,55%);opacity:0;transition:opacity .6s;display:flex;align-items:center;justify-content:center;}
+.hero__slide.is-active{opacity:1;z-index:1;}
+.hero__slide.is-leaving{opacity:0;}
+.hero__content{display:flex;flex-direction:column;gap:1rem;text-align:center;opacity:0;transform:translateY(20px);}
+.hero__slide.is-active .hero__content{animation:fadeUp .6s forwards;}
+.hero__dots{position:absolute;bottom:1rem;left:50%;transform:translateX(-50%);display:flex;gap:0.5rem;}
+.hero__dots button{width:10px;height:10px;border-radius:50%;background:rgba(255,255,255,0.5);border:none;}
+.hero__dots button[aria-current="true"]{background:var(--brand);}
+
+@keyframes fadeUp{to{opacity:1;transform:none;}}
 
 /* Benefits */
-.benefits {display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;text-align:center;}
-.benefits img {height:60px;margin:0 auto 0.5rem;}
+.benefits{display:grid;gap:1rem;text-align:center;}
+.benefits img{height:60px;margin:0 auto 0.5rem;}
+@media(max-width:767px){.benefits{grid-template-columns:repeat(2,1fr);} }
+@media(min-width:768px){.benefits{grid-template-columns:repeat(4,1fr);} }
 
-/* Media blocks */
-.media {display:flex;flex-direction:column;gap:2rem;}
-.media-item {display:flex;flex-direction:column;gap:1rem;}
-@media(min-width:768px){.media-item{flex-direction:row;align-items:center;} .media-item:nth-child(even){flex-direction:row-reverse;}}
-.media-item img{width:50%;}
+/* Content blocks */
+.content-block img{width:100%;height:auto;object-fit:cover;margin:1rem 0;}
 
 /* Reviews */
 .reviews-list{list-style:none;display:grid;gap:1rem;}
-.review{border:1px solid var(--line);padding:1rem;}
+.review{background:#fff;border-radius:12px;box-shadow:0 2px 6px rgba(0,0,0,0.05);padding:1rem;}
 .review .rating{color:var(--brand);}
+
+/* Animations */
+.fade-up{opacity:0;transform:translateY(20px);transition:opacity .6s,transform .6s;}
+.fade-up.is-visible{opacity:1;transform:none;}
+
+/* Modal */
+.modal[hidden]{display:none;}
+.modal{position:fixed;inset:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);opacity:0;pointer-events:none;transition:opacity 0.3s;z-index:2200;}
+.modal.open{opacity:1;pointer-events:auto;}
+.modal .overlay{position:absolute;inset:0;}
+.modal .modal-panel{background:var(--bg);color:var(--text);width:90%;max-width:400px;padding:1rem;border-radius:12px;position:relative;transform:translateY(20px);transition:transform 0.3s;max-height:90%;overflow:auto;}
+.modal.open .modal-panel{transform:translateY(0);}
+.modal-close{background:none;border:none;font-size:1.5rem;position:absolute;top:0.25rem;right:0.5rem;}
 
 /* Buy box */
 .product {display:grid;gap:2rem;}
@@ -122,7 +160,8 @@
 .buy-box{border:1px solid var(--line);padding:1rem;}
 .badges{display:flex;gap:0.5rem;margin:0.5rem 0;}
 .badge-pill{background:var(--brand);color:var(--header-bg);padding:0.25rem 0.5rem;font-size:0.875rem;}
-.sticky-bar{position:fixed;bottom:-100px;left:0;right:0;background:var(--bg);border-top:1px solid var(--line);padding:0.5rem;display:flex;justify-content:space-between;align-items:center;transition:bottom 0.3s;z-index:1500;}
+.sticky-bar{position:fixed;bottom:-100px;left:0;right:0;background:var(--bg);border-top:1px solid var(--line);padding:0.5rem;display:flex;justify-content:space-between;align-items:center;gap:0.5rem;transition:bottom 0.3s;z-index:1500;}
+.sticky-bar img{width:40px;height:40px;object-fit:cover;border-radius:4px;}
 .sticky-bar.show{bottom:0;}
 
 /* Accordion */
@@ -132,7 +171,7 @@
 .accordion-item.open .accordion-content{display:block;}
 
 /* Footer */
-.footer{background:var(--header-bg);color:var(--header-text);padding:2rem 0;}
+.footer{background:var(--header-bg);color:var(--header-text);padding:1.5rem 0;}
 .footer a{color:var(--header-text);}
 .footer a:hover{color:var(--brand-hover);}
 .footer-columns{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;}

--- a/g2-pro.html
+++ b/g2-pro.html
@@ -33,29 +33,29 @@
         <span class="badge-pill">Pagos seguros</span>
       </div>
       <ul id="quick-specs"></ul>
-      <button class="btn" onclick="addProduct(PRODUCT.sku,PRODUCT.nombre,PRODUCT.precioUSD)">Añadir al carrito</button>
-      <button class="btn secondary" onclick="addProduct(PRODUCT.sku,PRODUCT.nombre,PRODUCT.precioUSD);location.href='checkout.html'">Comprar ahora</button>
+      <button class="btn btn--primary" onclick="addProduct(PRODUCT.sku,PRODUCT.nombre,PRODUCT.precioUSD)">Añadir al carrito</button>
+      <button class="btn btn--dark" onclick="addProduct(PRODUCT.sku,PRODUCT.nombre,PRODUCT.precioUSD);location.href='checkout.html'">Comprar ahora</button>
     </div>
   </div>
 
   <section>
     <h2>Destacados</h2>
     <div class="benefits">
-      <div><h3>Suspensión doble</h3><p>Mayor control en terrenos irregulares.</p></div>
-      <div><h3>Frenos de disco</h3><p>Seguridad en cada frenada.</p></div>
-      <div><h3>Luces integradas</h3><p>Visibilidad nocturna mejorada.</p></div>
-      <div><h3>Plegado rápido</h3><p>Guárdalo en segundos.</p></div>
+      <div class="fade-up"><h3>Suspensión doble</h3><p>Mayor control en terrenos irregulares.</p></div>
+      <div class="fade-up"><h3>Frenos de disco</h3><p>Seguridad en cada frenada.</p></div>
+      <div class="fade-up"><h3>Luces integradas</h3><p>Visibilidad nocturna mejorada.</p></div>
+      <div class="fade-up"><h3>Plegado rápido</h3><p>Guárdalo en segundos.</p></div>
     </div>
   </section>
-  <section class="media">
-    <div class="media-item">
-      <img src="assets/section1.jpg" alt="Motor potente">
-      <div><h2>Motor de 600 W</h2><p>Acelera con fuerza en cada salida.</p></div>
-    </div>
-    <div class="media-item">
-      <img src="assets/section2.jpg" alt="Batería confiable">
-      <div><h2>Batería 48 V</h2><p>Hasta 58 km con una sola carga.</p></div>
-    </div>
+  <section class="content-block fade-up">
+    <h2>Motor de 600 W</h2>
+    <img src="assets/section1.jpg" alt="Motor potente">
+    <p>Acelera con fuerza en cada salida.</p>
+  </section>
+  <section class="content-block fade-up">
+    <h2>Batería 48 V</h2>
+    <img src="assets/section2.jpg" alt="Batería confiable">
+    <p>Hasta 58 km con una sola carga.</p>
   </section>
 
   <section>
@@ -74,6 +74,7 @@
 
   <section id="reviews">
     <h2>Reseñas de clientes</h2>
+    <button class="btn btn--primary" id="add-review-btn">Agregar reseña</button>
     <div id="reviews-list"></div>
   </section>
 </main>
@@ -91,12 +92,25 @@
         <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
         <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
         <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
-        <button type="submit" class="btn">Enviar</button>
+        <button type="submit" class="btn btn--primary">Enviar</button>
       </form>
     </div>
   </div>
 </aside>
-<div id="buy-bar" class="sticky-bar"><span>$1100</span><button class="btn" onclick="addProduct(PRODUCT.sku,PRODUCT.nombre,PRODUCT.precioUSD)">Añadir</button></div>
+<div id="buy-bar" class="sticky-bar"><img id="buy-bar-img" src="assets/g2pro_main.jpg" alt="G2 Pro"><span id="buy-bar-price">$1100</span><button class="btn btn--primary" onclick="addProduct(PRODUCT.sku,PRODUCT.nombre,PRODUCT.precioUSD)">Añadir al carrito</button></div>
+<div id="review-modal" class="modal" hidden>
+  <div class="overlay"></div>
+  <div class="modal-panel">
+    <button class="modal-close" aria-label="Cerrar">×</button>
+    <form id="review-form">
+      <div><label for="rev-name">Nombre</label><input id="rev-name" required></div>
+      <div><label for="rev-rating">Rating</label><input type="number" id="rev-rating" min="1" max="5" required></div>
+      <div><label for="rev-text">Comentario</label><textarea id="rev-text" required></textarea></div>
+      <div><label for="rev-img">Imagen (opcional)</label><input type="file" id="rev-img" accept="image/*"></div>
+      <button type="submit" class="btn btn--primary">Enviar</button>
+    </form>
+  </div>
+</div>
 <script type="application/ld+json">
 {
 "@context":"https://schema.org/","@type":"Product","name":"KuKirin G2 Pro","image":"assets/g2pro_main.jpg","description":"Monopatín eléctrico de 45 km/h y autonomía hasta 58 km.","sku":"KUKIRIN-G2PRO","brand":{"@type":"Brand","name":"KuKirin"},"offers":{"@type":"Offer","priceCurrency":"USD","price":"1100","availability":"https://schema.org/InStock"}}

--- a/index.html
+++ b/index.html
@@ -18,43 +18,57 @@
 <body>
 <header id="site-header"></header>
 <main>
-<section class="hero" style="background-image:url('assets/hero_home.jpg');background-size:cover;background-position:center;">
-  <div class="container">
-    <h1>KuKirin G2 Pro</h1>
-    <p>Envió 24h · Garantía 6 meses · Pagos seguros</p>
-    <div class="btn-group">
-      <a href="g2-pro.html" class="btn">Ver G2 Pro</a>
-      <a href="g2-pro.html#reviews" class="btn secondary">Leer reseñas</a>
+<section class="hero" role="region" aria-label="Carrusel destacado">
+  <div class="hero__slides">
+    <div class="hero__slide" data-bg="assets/hero_home.jpg">
+      <div class="hero__content">
+        <a href="g2-pro.html" class="btn btn--primary">Ver G2 Pro</a>
+        <a href="#reviews" class="btn btn--dark">Leer reseñas</a>
+      </div>
+    </div>
+    <div class="hero__slide" data-bg="assets/hero_home2.jpg">
+      <div class="hero__content">
+        <a href="g2-pro.html" class="btn btn--primary">Ver G2 Pro</a>
+        <a href="#reviews" class="btn btn--dark">Leer reseñas</a>
+      </div>
     </div>
   </div>
 </section>
 <section class="benefits container">
-  <div><img src="assets/benefit1.jpg" alt="Soporte real"><h3>Soporte real</h3><p>Asistencia por expertos.</p></div>
-  <div><img src="assets/benefit2.jpg" alt="Entrega express"><h3>Entrega express</h3><p>Llega en 24 horas.</p></div>
-  <div><img src="assets/benefit3.jpg" alt="Garantía 6 meses"><h3>Garantía 6 meses</h3><p>Cubre defectos de fábrica.</p></div>
-  <div><img src="assets/benefit4.jpg" alt="Pagos seguros"><h3>Pagos seguros</h3><p>Protección en cada transacción.</p></div>
+  <div class="fade-up"><img src="assets/benefit1.jpg" alt="Soporte real"><h3>Soporte real</h3><p>Asistencia por expertos.</p></div>
+  <div class="fade-up"><img src="assets/benefit2.jpg" alt="Entrega express"><h3>Entrega express</h3><p>Llega en 24 horas.</p></div>
+  <div class="fade-up"><img src="assets/benefit3.jpg" alt="Garantía 6 meses"><h3>Garantía 6 meses</h3><p>Cubre defectos de fábrica.</p></div>
+  <div class="fade-up"><img src="assets/benefit4.jpg" alt="Pagos seguros"><h3>Pagos seguros</h3><p>Protección en cada transacción.</p></div>
 </section>
-<section class="media container">
-  <div class="media-item">
-    <img src="assets/section1.jpg" alt="Suspensión avanzada">
-    <div>
-      <h2>Suspensión doble</h2>
-      <p>Amortigua las irregularidades de la calle para un viaje cómodo.</p>
-    </div>
-  </div>
-  <div class="media-item">
-    <img src="assets/section2.jpg" alt="Larga autonomía">
-    <div>
-      <h2>Autonomía extendida</h2>
-      <p>Hasta 58 km para que llegues más lejos sin preocupaciones.</p>
-    </div>
-  </div>
+<section class="content-block container fade-up">
+  <h2>Suspensión doble</h2>
+  <img src="assets/section1.jpg" alt="Suspensión avanzada">
+  <p>Amortigua las irregularidades de la calle para un viaje cómodo.</p>
 </section>
-<section class="container">
+<section class="content-block container fade-up">
+  <h2>Autonomía extendida</h2>
+  <img src="assets/section2.jpg" alt="Larga autonomía">
+  <p>Hasta 58 km para que llegues más lejos sin preocupaciones.</p>
+</section>
+<section class="container" id="reviews">
   <h2>Reseñas</h2>
+  <button class="btn btn--primary" id="add-review-btn">Agregar reseña</button>
   <div id="reviews-preview"></div>
-  <p style="text-align:center;margin-top:1rem;"><a class="btn" href="g2-pro.html#reviews">Ver más</a></p>
+  <p style="text-align:center;margin-top:1rem;"><a class="btn btn--primary" href="g2-pro.html#reviews">Ver más</a></p>
 </section>
+<div id="review-modal" class="modal" hidden>
+  <div class="overlay"></div>
+  <div class="modal-panel">
+    <button class="modal-close" aria-label="Cerrar">×</button>
+    <form id="review-form">
+      <div><label for="rev-name">Nombre</label><input id="rev-name" required></div>
+      <div><label for="rev-rating">Rating</label><input type="number" id="rev-rating" min="1" max="5" required></div>
+      <div><label for="rev-text">Comentario</label><textarea id="rev-text" required></textarea></div>
+      <div><label for="rev-img">Imagen (opcional)</label><input type="file" id="rev-img" accept="image/*"></div>
+      <button type="submit" class="btn btn--primary">Enviar</button>
+    </form>
+  </div>
+</div>
 </main>
 <footer id="site-footer"></footer>
 <div id="cart-drawer" class="drawer" aria-hidden="true"></div>
@@ -70,7 +84,7 @@
         <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
         <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
         <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
-        <button type="submit" class="btn">Enviar</button>
+        <button type="submit" class="btn btn--primary">Enviar</button>
       </form>
     </div>
   </div>

--- a/js/app.js
+++ b/js/app.js
@@ -39,7 +39,7 @@ const PRODUCT = {
 };
 
 // Reseñas
-const REVIEWS = [
+const INITIAL_REVIEWS = [
   {name:"Ana M.", date:"2024-05-02", rating:5, text:"Llegó rapidísimo y la potencia sorprende."},
   {name:"Carlos R.", date:"2024-04-18", rating:4, text:"Buen alcance, ideal para ir al trabajo."},
   {name:"Lucía P.", date:"2024-03-29", rating:5, text:"El frenado doble da mucha seguridad."},
@@ -54,10 +54,16 @@ const REVIEWS = [
   {name:"Ricardo N.", date:"2023-10-20", rating:4, text:"Sería genial que fuera plegado más liviano."}
 ];
 
+let STORED_REVIEWS = JSON.parse(localStorage.getItem('q360_reviews')||'[]');
+let REVIEWS = [...INITIAL_REVIEWS, ...STORED_REVIEWS];
+
 // Rating promedio
-const avg = REVIEWS.reduce((a,r)=>a+r.rating,0)/REVIEWS.length;
-PRODUCT.rating = Math.round(avg*10)/10;
-PRODUCT.reseñas = REVIEWS.length;
+function updateReviewStats(){
+  const avg = REVIEWS.reduce((a,r)=>a+r.rating,0)/REVIEWS.length;
+  PRODUCT.rating = Math.round(avg*10)/10;
+  PRODUCT.reseñas = REVIEWS.length;
+}
+updateReviewStats();
 
 // Render header & footer
 function renderHeader(){
@@ -66,49 +72,58 @@ function renderHeader(){
   header.innerHTML = `
   <div class="header">
     <div class="topbar container">
+      <button id="menu-btn" aria-label="Menú">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+        </svg>
+      </button>
       <a class="logo" href="index.html"><img src="assets/logo.png" alt="Quality360"></a>
-      <nav class="nav" aria-label="Principal">
+      <button id="cart-btn" aria-label="Carrito">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="9" cy="21" r="1"/>
+          <circle cx="20" cy="21" r="1"/>
+          <path d="M1 1h4l2.68 13.39a1 1 0 0 0 .99.81h9.72a1 1 0 0 0 .99-.81L23 6H6"/>
+        </svg>
+        <span id="cart-count" class="badge">0</span>
+      </button>
+    </div>
+    <nav class="nav" aria-label="Principal">
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="g2-pro.html">Monopatines</a></li>
+        <li class="has-sub"><button aria-haspopup="true" aria-expanded="false">Soporte ▾</button>
+          <div class="submenu" role="menu" hidden>
+            <a href="service.html#ayuda" role="menuitem">Centro de ayuda</a>
+            <a href="service.html#faq" role="menuitem">Preguntas frecuentes</a>
+            <a href="service.html#montaje" role="menuitem">Fácil montaje</a>
+            <a href="service.html#manual" role="menuitem">Manual del monopatín</a>
+            <a href="service.html#garantia" role="menuitem">Garantía</a>
+            <a href="service.html#envios" role="menuitem">Política de envíos</a>
+            <a href="service.html#reembolso" role="menuitem">Política de reembolso</a>
+            <a href="service.html#seguimiento" role="menuitem">Seguimiento de pedidos</a>
+          </div>
+        </li>
+      </ul>
+    </nav>
+  </div>
+  <aside id="navDrawer" hidden>
+    <div class="overlay"></div>
+    <div class="drawer-panel">
+      <button class="drawer-close" aria-label="Cerrar">×</button>
+      <nav>
         <ul>
-          <li><a href="index.html">Home</a></li>
-          <li class="has-sub"><button aria-haspopup="true" aria-expanded="false">Monopatines ▾</button>
-            <div class="submenu" role="menu" hidden>
-              <a href="g2-pro.html" role="menuitem">KuKirin G2 Pro</a>
-            </div>
-          </li>
-          <li class="has-sub"><button aria-haspopup="true" aria-expanded="false">Soporte ▾</button>
-            <div class="submenu" role="menu" hidden>
-              <a href="service.html#ayuda" role="menuitem">Centro de ayuda</a>
-              <a href="service.html#faq" role="menuitem">Preguntas frecuentes</a>
-              <a href="service.html#montaje" role="menuitem">Fácil montaje</a>
-              <a href="service.html#manual" role="menuitem">Manual del patinete</a>
-              <a href="service.html#garantia" role="menuitem">Garantía</a>
-              <a href="service.html#envios" role="menuitem">Política de envíos</a>
-              <a href="service.html#reembolso" role="menuitem">Política de reembolso</a>
-              <a href="service.html#seguimiento" role="menuitem">Seguimiento de pedidos</a>
-              <a href="service.html#distribuidor" role="menuitem">Conviértete en distribuidor</a>
-            </div>
-          </li>
+          <li><a href="g2-pro.html">Monopatines</a></li>
+          <li><a href="service.html#ayuda">Centro de ayuda</a></li>
+          <li><a href="service.html#faq">Preguntas frecuentes</a></li>
+          <li><a href="service.html#manual">Manual del monopatín</a></li>
+          <li><a href="service.html#garantia">Garantía</a></li>
+          <li><a href="service.html#envios">Política de envíos</a></li>
+          <li><a href="service.html#reembolso">Política de reembolso</a></li>
+          <li><a href="service.html#seguimiento">Seguimiento de pedidos</a></li>
         </ul>
       </nav>
-      <div class="actions">
-        <button id="contact-btn" aria-controls="contactDrawer" aria-expanded="false" aria-label="Contacto">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M20 21v-2a4 4 0 0 0-3-3.87"/>
-            <path d="M4 21v-2a4 4 0 0 1 3-3.87"/>
-            <circle cx="12" cy="7" r="4"/>
-          </svg>
-        </button>
-        <button id="cart-btn" aria-label="Carrito">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="9" cy="21" r="1"/>
-            <circle cx="20" cy="21" r="1"/>
-            <path d="M1 1h4l2.68 13.39a1 1 0 0 0 .99.81h9.72a1 1 0 0 0 .99-.81L23 6H6"/>
-          </svg>
-          <span id="cart-count" class="badge">0</span>
-        </button>
-      </div>
     </div>
-  </div>`;
+  </aside>`;
 }
 
 function renderFooter(){
@@ -130,10 +145,10 @@ function renderFooter(){
         <p><a href="service.html#garantia">Garantía</a></p>
       </div>
       <div>
-        <h4>Newsletter</h4>
+        <h4>Suscríbete</h4>
         <form onsubmit="event.preventDefault();alert('Demo');">
           <input type="email" placeholder="Tu email" aria-label="Email">
-          <button class="btn" type="submit">Suscribirme</button>
+          <button class="btn btn--primary" type="submit">Suscribirme</button>
         </form>
       </div>
     </div>
@@ -151,10 +166,67 @@ function renderReviews(targetId, list){
     const li = document.createElement('li');
     li.className = 'review';
     li.innerHTML = `<strong>${r.name}</strong> <span class="rating">${'★'.repeat(r.rating)}</span><br><small>${r.date}</small><p>${r.text}</p>`;
+    if(r.img){
+      const img = document.createElement('img');
+      img.src = r.img;
+      img.alt = '';
+      img.style.marginTop = '0.5rem';
+      li.appendChild(img);
+    }
     ul.appendChild(li);
   });
   el.innerHTML = '';
   el.appendChild(ul);
+}
+
+function initReviewForm(){
+  const btn = document.getElementById('add-review-btn');
+  const modal = document.getElementById('review-modal');
+  if(!btn || !modal) return;
+  const overlay = modal.querySelector('.overlay');
+  const closeBtn = modal.querySelector('.modal-close');
+  const form = modal.querySelector('#review-form');
+
+  function open(){
+    modal.hidden = false;
+    requestAnimationFrame(()=> modal.classList.add('open'));
+  }
+  function close(){
+    modal.classList.remove('open');
+    modal.addEventListener('transitionend', ()=>{modal.hidden=true;}, {once:true});
+  }
+
+  btn.addEventListener('click', open);
+  overlay.addEventListener('click', close);
+  closeBtn.addEventListener('click', close);
+  document.addEventListener('keydown', e=>{if(e.key==='Escape') close();});
+
+  form.addEventListener('submit', e=>{
+    e.preventDefault();
+    const name = form.querySelector('#rev-name').value.trim();
+    const rating = parseInt(form.querySelector('#rev-rating').value,10);
+    const text = form.querySelector('#rev-text').value.trim();
+    const file = form.querySelector('#rev-img').files[0];
+    if(!name || !rating || !text) return;
+    function save(img=''){
+      const review = {name, rating, text, img, date:new Date().toISOString().split('T')[0]};
+      STORED_REVIEWS.push(review);
+      localStorage.setItem('q360_reviews', JSON.stringify(STORED_REVIEWS));
+      REVIEWS = [...INITIAL_REVIEWS, ...STORED_REVIEWS];
+      updateReviewStats();
+      renderReviews('reviews-list', REVIEWS);
+      renderReviews('reviews-preview', REVIEWS.slice(0,3));
+      form.reset();
+      close();
+    }
+    if(file){
+      const reader = new FileReader();
+      reader.onload = () => save(reader.result);
+      reader.readAsDataURL(file);
+    }else{
+      save();
+    }
+  });
 }
 
 // Quick specs
@@ -202,6 +274,10 @@ function renderBuyBox(){
   if(price){price.textContent = `$${PRODUCT.precioUSD}`;}
   if(old){old.textContent = `$${PRODUCT.precioAntesUSD}`;}
   if(rating){rating.textContent = `${PRODUCT.rating} (${PRODUCT.reseñas})`;}
+  const barPrice = $('#buy-bar-price');
+  const barImg = $('#buy-bar-img');
+  if(barPrice) barPrice.textContent = `$${PRODUCT.precioUSD}`;
+  if(barImg) barImg.src = PRODUCT.images.hero;
 }
 
 // Init
@@ -216,4 +292,5 @@ window.addEventListener('DOMContentLoaded', () => {
   renderSpecs();
   initGallery();
   renderBuyBox();
+  initReviewForm();
 });

--- a/js/cart.js
+++ b/js/cart.js
@@ -53,7 +53,7 @@ function renderCart(){
     <div class="drawer-footer">
       <textarea id="cart-note" placeholder="Nota de pedido">${localStorage.getItem(NOTE_KEY)||''}</textarea>
       <p>Subtotal: <span id="cart-subtotal">$0</span></p>
-      <button class="btn" id="checkout-btn">Verificar</button>
+      <button class="btn btn--primary" id="checkout-btn">Verificar</button>
     </div>`;
   const itemsEl = document.getElementById('cart-items');
   const cart = getCart();

--- a/js/ui.js
+++ b/js/ui.js
@@ -82,6 +82,31 @@ function initCartDrawer(){
   document.addEventListener('keydown', e => { if(e.key === 'Escape') drawer.classList.remove('open'); });
 }
 
+function initMenuDrawer(){
+  const btn = document.getElementById('menu-btn');
+  const drawer = document.getElementById('navDrawer');
+  if(!btn || !drawer) return;
+  const overlay = drawer.querySelector('.overlay');
+  const closeBtn = drawer.querySelector('.drawer-close');
+
+  function open(){
+    closeNavMenus();
+    btn.setAttribute('aria-expanded','true');
+    drawer.hidden = false;
+    requestAnimationFrame(()=> drawer.classList.add('open'));
+  }
+  function close(){
+    btn.setAttribute('aria-expanded','false');
+    drawer.classList.remove('open');
+    drawer.addEventListener('transitionend',()=>{drawer.hidden=true;}, {once:true});
+  }
+
+  btn.addEventListener('click', open);
+  overlay.addEventListener('click', close);
+  closeBtn.addEventListener('click', close);
+  document.addEventListener('keydown', e=>{if(e.key==='Escape') close();});
+}
+
 function initContactDrawer(){
   const btn = document.getElementById('contact-btn');
   const drawer = document.getElementById('contactDrawer');
@@ -136,11 +161,95 @@ function initStickyBar(){
   });
 }
 
+function initFadeUp(){
+  const els = document.querySelectorAll('.fade-up');
+  if(!els.length) return;
+  const io = new IntersectionObserver((entries)=>{
+    entries.forEach(e=>{
+      if(e.isIntersecting){
+        e.target.classList.add('is-visible');
+        io.unobserve(e.target);
+      }
+    });
+  });
+  els.forEach(el=>io.observe(el));
+}
+
+function initHeroCarousel(){
+  const hero = document.querySelector('.hero');
+  if(!hero) return;
+  const slides = Array.from(hero.querySelectorAll('.hero__slide'));
+  // remove slides with missing images
+  slides.forEach(slide=>{
+    const src = slide.dataset.bg;
+    const img = new Image();
+    img.src = src;
+    img.onload = () => slide.style.backgroundImage = `linear-gradient(0deg, rgba(0,0,0,.35), rgba(0,0,0,.10)), url('${src}')`;
+    img.onerror = () => slide.remove();
+  });
+  let current = 0;
+  const dots = document.createElement('div');
+  dots.className = 'hero__dots';
+  hero.appendChild(dots);
+
+  function go(i){
+    const slidesArr = hero.querySelectorAll('.hero__slide');
+    if(!slidesArr.length) return;
+    slidesArr[current].classList.remove('is-active');
+    slidesArr[current].classList.add('is-leaving');
+    setTimeout(()=>slidesArr[current].classList.remove('is-leaving'),600);
+    current = i;
+    slidesArr[current].classList.add('is-active');
+    dots.querySelectorAll('button').forEach((b,idx)=>b.setAttribute('aria-current', idx===current));
+  }
+
+  function next(){
+    const slidesArr = hero.querySelectorAll('.hero__slide');
+    go((current+1)%slidesArr.length);
+  }
+
+  function start(){
+    timer = setInterval(next,2000);
+  }
+  function stop(){clearInterval(timer);}
+
+  let timer;
+
+  function initDots(){
+    const slidesArr = hero.querySelectorAll('.hero__slide');
+    dots.innerHTML = '';
+    slidesArr.forEach((_,i)=>{
+      const b = document.createElement('button');
+      b.type='button';
+      b.setAttribute('aria-controls', `hero-slide-${i}`);
+      if(i===0) b.setAttribute('aria-current','true');
+      b.addEventListener('click', ()=>{stop(); go(i); start();});
+      dots.appendChild(b);
+    });
+    if(slidesArr.length<=1) dots.style.display='none';
+  }
+
+  initDots();
+  hero.querySelectorAll('.hero__slide').forEach((s,i)=>{s.id=`hero-slide-${i}`;});
+  hero.addEventListener('mouseenter', stop);
+  hero.addEventListener('mouseleave', start);
+  document.addEventListener('visibilitychange', ()=>{document.hidden?stop():start();});
+  let startX;
+  hero.addEventListener('touchstart',e=>{startX=e.touches[0].clientX;});
+  hero.addEventListener('touchend',e=>{if(startX==null)return;const dx=e.changedTouches[0].clientX-startX;if(Math.abs(dx)>40){dx>0?go((current-1+hero.querySelectorAll('.hero__slide').length)%hero.querySelectorAll('.hero__slide').length):next();}startX=null;});
+
+  hero.querySelectorAll('.hero__slide')[0]?.classList.add('is-active');
+  start();
+}
+
 window.addEventListener('DOMContentLoaded',()=>{
   initNav();
   initCartDrawer();
+  initMenuDrawer();
   initContactDrawer();
   initAccordion();
   initStickyBar();
+  initFadeUp();
+  initHeroCarousel();
 });
 

--- a/service.html
+++ b/service.html
@@ -43,7 +43,7 @@
         <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
         <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
         <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
-        <button type="submit" class="btn">Enviar</button>
+        <button type="submit" class="btn btn--primary">Enviar</button>
       </form>
     </div>
   </div>

--- a/success.html
+++ b/success.html
@@ -20,7 +20,7 @@
 <main class="container" style="text-align:center;padding:4rem 0;">
   <h1>¡Gracias por tu compra!</h1>
   <p>Tu pedido está en proceso. Recibirás un email con los detalles.</p>
-  <a class="btn" href="index.html">Volver al inicio</a>
+  <a class="btn btn--primary" href="index.html">Volver al inicio</a>
 </main>
 <footer id="site-footer"></footer>
 <div id="cart-drawer" class="drawer" aria-hidden="true"></div>
@@ -36,7 +36,7 @@
         <div><label for="contactName">Nombre</label><input type="text" id="contactName"></div>
         <div><label for="contactEmail">Email</label><input type="email" id="contactEmail" required></div>
         <div><label for="contactMessage">Mensaje</label><textarea id="contactMessage"></textarea></div>
-        <button type="submit" class="btn">Enviar</button>
+        <button type="submit" class="btn btn--primary">Enviar</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Diseño mobile-first con header negro sticky, drawer lateral accesible y nuevo footer compacto.
- Botones renovados estilo píldora y carrusel responsivo en el hero de Home.
- Reseñas reestilizadas con modal para agregar opiniones guardadas en localStorage y CTA inferior fijo en la PDP.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dfc17e698832ea7ac240809839d7a