### PR TITLE
chore: refine mobile header and drawers

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -58,7 +58,7 @@
   </aside>
 </main>
 <footer id="site-footer"></footer>
-<div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<div id="cart-drawer" class="drawer" hidden></div>
 <aside id="contactDrawer" hidden>
   <div class="overlay"></div>
   <div class="drawer-panel">

--- a/css/base.css
+++ b/css/base.css
@@ -45,7 +45,7 @@ button {
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding-inline: max(16px, env(safe-area-inset-left)) max(16px, env(safe-area-inset-right));
 }
 
 .btn {

--- a/css/components.css
+++ b/css/components.css
@@ -4,16 +4,18 @@
   top: 0;
   background: var(--header-bg);
   color: var(--header-text);
-  border-bottom: 1px solid rgba(255,255,255,0.05);
   z-index: 1000;
 }
 .topbar {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  padding: 0.5rem 0;
+  padding-block: 0.5rem;
+  min-height:56px;
 }
-.logo img {height:40px;}
+.logo{display:flex;align-items:center;gap:0.5rem;font-weight:700;justify-self:center;}
+.logo img{height:40px;}
+.topbar button svg{width:24px;height:24px;}
 .nav {justify-self:center;display:none;}
 .nav ul {list-style:none;display:flex;gap:1rem;}
 .nav .has-sub {position:relative;}
@@ -90,19 +92,24 @@
 }
 
 /* Drawer */
-.drawer {position:fixed;top:0;right:-100%;width:300px;height:100%;background:var(--bg);color:var(--text);box-shadow:-2px 0 6px rgba(0,0,0,0.2);transition:right 0.3s;z-index:2000;display:flex;flex-direction:column;}
-.drawer.open {right:0;}
-.drawer-header {display:flex;justify-content:space-between;align-items:center;padding:1rem;border-bottom:1px solid var(--line);}
-.drawer-content {flex:1;overflow:auto;padding:1rem;}
-.drawer-footer {padding:1rem;border-top:1px solid var(--line);}
+.drawer[hidden]{display:none;}
+.drawer{position:fixed;inset:0;display:flex;justify-content:flex-end;background:rgba(0,0,0,0.5);opacity:0;pointer-events:none;transition:opacity 0.3s;z-index:2000;}
+.drawer.open{opacity:1;pointer-events:auto;}
+.drawer .drawer-panel{background:var(--bg);color:var(--text);width:min(86vw,420px);height:100%;box-shadow:-2px 0 6px rgba(0,0,0,0.2);display:flex;flex-direction:column;transform:translateX(100%);transition:transform 0.3s;}
+.drawer.open .drawer-panel{transform:translateX(0);}
+.drawer .overlay{flex:1;}
+.drawer-header{display:flex;justify-content:space-between;align-items:center;padding:1rem;border-bottom:1px solid var(--line);}
+.drawer-content{flex:1;overflow:auto;padding:1rem;}
+.drawer-footer{padding:1rem;border-top:1px solid var(--line);}
 .cart-item {display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem;}
 .cart-item button{padding:0.25rem 0.5rem;background:var(--line);}
+.drawer-close{font-size:24px;min-width:44px;min-height:44px;display:flex;align-items:center;justify-content:center;}
 
 /* Nav drawer */
 #navDrawer[hidden]{display:none;}
 #navDrawer{position:fixed;inset:0;display:flex;justify-content:flex-start;background:rgba(0,0,0,0.5);opacity:0;pointer-events:none;transition:opacity 0.3s;z-index:2100;}
 #navDrawer.open{opacity:1;pointer-events:auto;}
-#navDrawer .drawer-panel{background:var(--bg);color:var(--text);width:260px;max-width:90%;height:100%;box-shadow:2px 0 6px rgba(0,0,0,0.2);display:flex;flex-direction:column;transform:translateX(-100%);transition:transform 0.3s;}
+#navDrawer .drawer-panel{background:var(--bg);color:var(--text);width:min(86vw,420px);height:100%;box-shadow:2px 0 6px rgba(0,0,0,0.2);display:flex;flex-direction:column;transform:translateX(-100%);transition:transform 0.3s;}
 #navDrawer.open .drawer-panel{transform:translateX(0);}
 #navDrawer .overlay{flex:1;}
 #navDrawer nav ul{list-style:none;padding:1rem;}
@@ -137,7 +144,17 @@
 /* Reviews */
 .reviews-list{list-style:none;display:grid;gap:1rem;}
 .review{background:#fff;border-radius:12px;box-shadow:0 2px 6px rgba(0,0,0,0.05);padding:1rem;}
-.review .rating{color:var(--brand);}
+.review .rating{display:inline-block;}
+.review .rating .filled{color:var(--brand);}
+.review .rating .empty{color:#ccc;}
+#add-review-btn{margin-bottom:1rem;}
+
+.rating-select{display:flex;flex-direction:row-reverse;gap:4px;}
+.rating-select input{display:none;}
+.rating-select label{font-size:24px;color:#ccc;cursor:pointer;}
+.rating-select label:hover,
+.rating-select label:hover ~ label,
+.rating-select input:checked ~ label{color:var(--brand);}
 
 /* Animations */
 .fade-up{opacity:0;transform:translateY(20px);transition:opacity .6s,transform .6s;}
@@ -175,6 +192,8 @@
 .footer a{color:var(--header-text);}
 .footer a:hover{color:var(--brand-hover);}
 .footer-columns{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;}
+.footer form{display:flex;flex-direction:column;gap:0.75rem;}
+@media(min-width:768px){.footer form{flex-direction:row;align-items:center;}}
 
 /* Checkout */
 .checkout{display:flex;flex-direction:column;gap:2rem;}

--- a/g2-pro.html
+++ b/g2-pro.html
@@ -79,7 +79,7 @@
   </section>
 </main>
 <footer id="site-footer"></footer>
-<div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<div id="cart-drawer" class="drawer" hidden></div>
 <aside id="contactDrawer" hidden>
   <div class="overlay"></div>
   <div class="drawer-panel">
@@ -104,7 +104,16 @@
     <button class="modal-close" aria-label="Cerrar">×</button>
     <form id="review-form">
       <div><label for="rev-name">Nombre</label><input id="rev-name" required></div>
-      <div><label for="rev-rating">Rating</label><input type="number" id="rev-rating" min="1" max="5" required></div>
+      <div>
+        <span>Rating</span>
+        <div class="rating-select">
+          <input type="radio" id="rev-star5" name="rev-rating" value="5" required><label for="rev-star5">★</label>
+          <input type="radio" id="rev-star4" name="rev-rating" value="4"><label for="rev-star4">★</label>
+          <input type="radio" id="rev-star3" name="rev-rating" value="3"><label for="rev-star3">★</label>
+          <input type="radio" id="rev-star2" name="rev-rating" value="2"><label for="rev-star2">★</label>
+          <input type="radio" id="rev-star1" name="rev-rating" value="1"><label for="rev-star1">★</label>
+        </div>
+      </div>
       <div><label for="rev-text">Comentario</label><textarea id="rev-text" required></textarea></div>
       <div><label for="rev-img">Imagen (opcional)</label><input type="file" id="rev-img" accept="image/*"></div>
       <button type="submit" class="btn btn--primary">Enviar</button>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,16 @@
     <button class="modal-close" aria-label="Cerrar">×</button>
     <form id="review-form">
       <div><label for="rev-name">Nombre</label><input id="rev-name" required></div>
-      <div><label for="rev-rating">Rating</label><input type="number" id="rev-rating" min="1" max="5" required></div>
+      <div>
+        <span>Rating</span>
+        <div class="rating-select">
+          <input type="radio" id="rev-star5" name="rev-rating" value="5" required><label for="rev-star5">★</label>
+          <input type="radio" id="rev-star4" name="rev-rating" value="4"><label for="rev-star4">★</label>
+          <input type="radio" id="rev-star3" name="rev-rating" value="3"><label for="rev-star3">★</label>
+          <input type="radio" id="rev-star2" name="rev-rating" value="2"><label for="rev-star2">★</label>
+          <input type="radio" id="rev-star1" name="rev-rating" value="1"><label for="rev-star1">★</label>
+        </div>
+      </div>
       <div><label for="rev-text">Comentario</label><textarea id="rev-text" required></textarea></div>
       <div><label for="rev-img">Imagen (opcional)</label><input type="file" id="rev-img" accept="image/*"></div>
       <button type="submit" class="btn btn--primary">Enviar</button>
@@ -71,7 +80,7 @@
 </div>
 </main>
 <footer id="site-footer"></footer>
-<div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<div id="cart-drawer" class="drawer" hidden></div>
 <aside id="contactDrawer" hidden>
   <div class="overlay"></div>
   <div class="drawer-panel">

--- a/js/app.js
+++ b/js/app.js
@@ -73,13 +73,13 @@ function renderHeader(){
   <div class="header">
     <div class="topbar container">
       <button id="menu-btn" aria-label="Menú">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
         </svg>
       </button>
-      <a class="logo" href="index.html"><img src="assets/logo.png" alt="Quality360"></a>
+      <a class="logo" href="index.html"><img src="assets/logo.png" alt="Quality360"><span>Quality360</span></a>
       <button id="cart-btn" aria-label="Carrito">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <circle cx="9" cy="21" r="1"/>
           <circle cx="20" cy="21" r="1"/>
           <path d="M1 1h4l2.68 13.39a1 1 0 0 0 .99.81h9.72a1 1 0 0 0 .99-.81L23 6H6"/>
@@ -165,7 +165,8 @@ function renderReviews(targetId, list){
   list.forEach(r=>{
     const li = document.createElement('li');
     li.className = 'review';
-    li.innerHTML = `<strong>${r.name}</strong> <span class="rating">${'★'.repeat(r.rating)}</span><br><small>${r.date}</small><p>${r.text}</p>`;
+    const stars = Array.from({length:5},(_,i)=>`<span class="${i<r.rating?'filled':'empty'}">★</span>`).join('');
+    li.innerHTML = `<strong>${r.name}</strong> <span class="rating">${stars}</span><br><small>${r.date}</small><p>${r.text}</p>`;
     if(r.img){
       const img = document.createElement('img');
       img.src = r.img;
@@ -204,7 +205,8 @@ function initReviewForm(){
   form.addEventListener('submit', e=>{
     e.preventDefault();
     const name = form.querySelector('#rev-name').value.trim();
-    const rating = parseInt(form.querySelector('#rev-rating').value,10);
+    const ratingEl = form.querySelector('input[name="rev-rating"]:checked');
+    const rating = ratingEl ? parseInt(ratingEl.value,10) : 0;
     const text = form.querySelector('#rev-text').value.trim();
     const file = form.querySelector('#rev-img').files[0];
     if(!name || !rating || !text) return;

--- a/js/cart.js
+++ b/js/cart.js
@@ -45,15 +45,18 @@ function renderCart(){
   const drawer = document.getElementById('cart-drawer');
   if(!drawer) return;
   drawer.innerHTML = `
-    <div class="drawer-header">
-      <h2>Carrito</h2>
-      <button class="drawer-close" aria-label="Cerrar">×</button>
-    </div>
-    <div class="drawer-content" id="cart-items"></div>
-    <div class="drawer-footer">
-      <textarea id="cart-note" placeholder="Nota de pedido">${localStorage.getItem(NOTE_KEY)||''}</textarea>
-      <p>Subtotal: <span id="cart-subtotal">$0</span></p>
-      <button class="btn btn--primary" id="checkout-btn">Verificar</button>
+    <div class="overlay"></div>
+    <div class="drawer-panel">
+      <div class="drawer-header">
+        <h2>Carrito</h2>
+        <button class="drawer-close" aria-label="Cerrar">×</button>
+      </div>
+      <div class="drawer-content" id="cart-items"></div>
+      <div class="drawer-footer">
+        <textarea id="cart-note" placeholder="Nota de pedido">${localStorage.getItem(NOTE_KEY)||''}</textarea>
+        <p>Subtotal: <span id="cart-subtotal">$0</span></p>
+        <button class="btn btn--primary" id="checkout-btn">Verificar</button>
+      </div>
     </div>`;
   const itemsEl = document.getElementById('cart-items');
   const cart = getCart();

--- a/js/ui.js
+++ b/js/ui.js
@@ -72,14 +72,25 @@ function initCartDrawer(){
   const btn = document.getElementById('cart-btn');
   const drawer = document.getElementById('cart-drawer');
   if(!btn || !drawer) return;
-  btn.addEventListener('click', () => {
+  const overlay = drawer.querySelector('.overlay');
+  const closeBtn = drawer.querySelector('.drawer-close');
+
+  function open(){
     closeNavMenus();
-    drawer.classList.add('open');
-  });
-  drawer.addEventListener('click', e => {
-    if(e.target.classList.contains('drawer-close') || e.target === drawer) drawer.classList.remove('open');
-  });
-  document.addEventListener('keydown', e => { if(e.key === 'Escape') drawer.classList.remove('open'); });
+    drawer.hidden = false;
+    requestAnimationFrame(()=> drawer.classList.add('open'));
+    document.body.style.overflow = 'hidden';
+  }
+  function close(){
+    drawer.classList.remove('open');
+    drawer.addEventListener('transitionend',()=>{drawer.hidden=true;},{once:true});
+    document.body.style.overflow = '';
+  }
+
+  btn.addEventListener('click', open);
+  overlay.addEventListener('click', close);
+  closeBtn.addEventListener('click', close);
+  document.addEventListener('keydown', e => { if(e.key === 'Escape') close(); });
 }
 
 function initMenuDrawer(){
@@ -94,11 +105,13 @@ function initMenuDrawer(){
     btn.setAttribute('aria-expanded','true');
     drawer.hidden = false;
     requestAnimationFrame(()=> drawer.classList.add('open'));
+    document.body.style.overflow = 'hidden';
   }
   function close(){
     btn.setAttribute('aria-expanded','false');
     drawer.classList.remove('open');
     drawer.addEventListener('transitionend',()=>{drawer.hidden=true;}, {once:true});
+    document.body.style.overflow = '';
   }
 
   btn.addEventListener('click', open);

--- a/service.html
+++ b/service.html
@@ -30,7 +30,7 @@
   <section id="distribuidor" class="service-section"><h2>Conviértete en distribuidor</h2><p>Contenido próximamente.</p></section>
 </main>
 <footer id="site-footer"></footer>
-<div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<div id="cart-drawer" class="drawer" hidden></div>
 <aside id="contactDrawer" hidden>
   <div class="overlay"></div>
   <div class="drawer-panel">

--- a/success.html
+++ b/success.html
@@ -23,7 +23,7 @@
   <a class="btn btn--primary" href="index.html">Volver al inicio</a>
 </main>
 <footer id="site-footer"></footer>
-<div id="cart-drawer" class="drawer" aria-hidden="true"></div>
+<div id="cart-drawer" class="drawer" hidden></div>
 <aside id="contactDrawer" hidden>
   <div class="overlay"></div>
   <div class="drawer-panel">


### PR DESCRIPTION
## Summary
- polish mobile header with centered logo, safe area padding and solid background
- add overlay-based drawers for menu and cart with body scroll lock
- enrich reviews with star rating UI and spaced newsletter form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4c1ae1dc832e91bbd41317b53803