### PR TITLE
Add contact page with hero and fade-in animations

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="#333333" />
+  <text x="50" y="60" font-size="45" text-anchor="middle" fill="#ffffff" font-family="sans-serif" font-weight="600">IL</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contacto – InnovaLabs</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <nav class="top-bar">
+      <a href="#" class="branding" aria-label="Inicio">
+        <img src="assets/logo.svg" alt="Logo de InnovaLabs" class="logo" />
+        <span class="brand-name">InnovaLabs</span>
+      </a>
+    </nav>
+    <div class="hero-content">
+      <h1 class="fade-in delay-1">Contacto</h1>
+      <p class="fade-in delay-2">Innovación tecnológica a tu alcance.</p>
+      <a href="https://wa.me/59896594592" class="btn cta fade-in delay-3" target="_blank" rel="noopener" aria-label="Abrir chat de WhatsApp">
+        Escríbenos por WhatsApp
+      </a>
+    </div>
+  </header>
+
+  <main>
+    <section class="contact-block" aria-label="Información de contacto">
+      <h2 class="fade-in">Hablemos</h2>
+      <ul class="contact-list">
+        <li class="fade-in delay-1">
+          <span class="contact-label">WhatsApp:</span>
+          <a href="https://wa.me/59896594592" target="_blank" rel="noopener" aria-label="Enviar mensaje por WhatsApp">
+            +598 96 594 592
+          </a>
+        </li>
+        <li class="fade-in delay-2">
+          <span class="contact-label">Email:</span>
+          <a href="mailto:papolight2020@gmail.com" aria-label="Enviar correo electrónico a papolight2020@gmail.com">
+            papolight2020@gmail.com
+          </a>
+        </li>
+        <li class="fade-in delay-3">
+          <span class="contact-label">Ubicación:</span>
+          <address>Montevideo, Uruguay</address>
+        </li>
+      </ul>
+    </section>
+  </main>
+
+  <footer class="site-footer fade-in" role="contentinfo">
+    <p>&copy; 2024 InnovaLabs. Todos los derechos reservados.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        obs.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,179 @@
+:root {
+  --primary: #444444;
+  --primary-dark: #000000;
+  --text-light: #f5f5f5;
+  --text-muted: #cccccc;
+  --bg-dark: #111111;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 1.6;
+  color: var(--text-light);
+  background: linear-gradient(135deg, #1e1e1e 0%, #2b2b2b 100%);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.top-bar {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  color: var(--text-light);
+}
+
+.logo {
+  width: 40px;
+  height: 40px;
+  margin-right: 0.5rem;
+}
+
+.brand-name {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: var(--text-light);
+  background-image: url('https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1350&q=80');
+  background-size: cover;
+  background-position: center;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.hero-content {
+  position: relative;
+  padding: 0 1rem;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.hero-content p {
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: var(--primary);
+  color: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.2s ease-in-out;
+}
+
+.btn:hover,
+.btn:focus {
+  background: var(--primary-dark);
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+main {
+  padding: 2rem 1rem 4rem;
+  color: var(--text-light);
+}
+
+.contact-block {
+  max-width: 700px;
+  margin: 0 auto;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 1.5rem;
+  border-radius: 8px;
+}
+
+.contact-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+}
+
+.contact-label {
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+
+.contact-list li {
+  margin: 1rem 0;
+}
+
+.contact-list a {
+  color: var(--text-light);
+  text-decoration: none;
+}
+
+.contact-list a:hover,
+.contact-list a:focus {
+  text-decoration: underline;
+  outline: 2px dashed var(--text-light);
+  outline-offset: 3px;
+}
+
+.site-footer {
+  background: var(--bg-dark);
+  color: var(--text-muted);
+  text-align: center;
+  padding: 1.5rem 1rem;
+  font-size: 0.875rem;
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.fade-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+:focus-visible {
+  outline: 2px dashed var(--text-light);
+  outline-offset: 4px;
+}
+
+.delay-1 { transition-delay: 0.1s; }
+.delay-2 { transition-delay: 0.2s; }
+.delay-3 { transition-delay: 0.3s; }
+.delay-4 { transition-delay: 0.4s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Rebrand contact page as InnovaLabs with neutral logo
- Apply full-page gradient background and grey color palette
- Introduce staggered fade-in animations for hero and contact details

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a87c863300832eb6b7e53f1e8a9beb